### PR TITLE
Accept Decathlon HR sensors

### DIFF
--- a/openhrv/sensor.py
+++ b/openhrv/sensor.py
@@ -34,7 +34,7 @@ class SensorScanner(QObject):
         polar_sensors: list[QBluetoothDeviceInfo] = [
             d
             for d in self.scanner.discoveredDevices()
-            if "Polar" in str(d.name()) and d.rssi() <= 0
+            if ("Polar" in str(d.name()) or "Decathlon Dual HR" in str(d.name())) and d.rssi() <= 0
         ]  # https://www.mokoblue.com/measures-of-bluetooth-rssi/
         if not polar_sensors:
             self.status_update.emit("Couldn't find sensors.")


### PR DESCRIPTION
I have a Decathlon HR belt, and it looks like it uses the same protocol as the Polar (while being cheaper). So including it in the scan results is enough, and from then on everything seems to work the same.

Only tested on my own belt (model ZT26D).