### PR TITLE
test: add minimal headless smoke test and run it in CI (#28)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,5 +22,6 @@
                 }
             }
         }
-    }
+    },
+    "postCreateCommand": "./.devcontainer/post_create_commands.sh"
 }

--- a/.devcontainer/post_create_commands.sh
+++ b/.devcontainer/post_create_commands.sh
@@ -1,0 +1,4 @@
+pip install --upgrade pip
+pip install -e .[dev,build,test]
+apt-get update
+apt-get install -y libdbus-1-3 libgl1 libegl1 libxkbcommon0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+name: test
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+
+  test:
+
+    runs-on: ubuntu-24.04
+
+    env:
+      # Run Qt headless: no display server is available on CI runners.
+      QT_QPA_PLATFORM: offscreen
+
+    steps:
+
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-python@v5
+      with:
+          python-version: "3.12"
+
+    - name: Install system libraries for headless Qt
+      run: |
+          sudo apt-get update
+          sudo apt-get install -y libegl1 libxkbcommon0
+
+    - name: Install dependencies
+      run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .[test]
+
+    - name: Run tests
+      run: pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,15 @@ dependencies = ["PySide6 >= 6.10"]
 [project.optional-dependencies]
 dev = ["snakeviz"]
 build = ["pyinstaller"]
+test = ["pytest"]
 
 [tool.mypy]
 check_untyped_defs = true
+
+[tool.pytest.ini_options]
+# Collect tests from test/; conftest.py puts that dir on sys.path so the smoke
+# test can import the existing mock sensor as a top-level `app` module.
+testpaths = ["test"]
 
 [project.gui-scripts]
 # command line entry points

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,19 @@
+import os
+
+# Run Qt without a display server (CI has no X11/Wayland, no GPU).
+# Must be set before QApplication is created.
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+from PySide6.QtWidgets import QApplication
+
+
+@pytest.fixture(scope="session")
+def qapp():
+    """A single offscreen QApplication for the whole test session.
+
+    QObject subclasses (Model, Pacer, View) require a running QApplication,
+    but the offscreen platform plugin means no real window is ever shown.
+    """
+    app = QApplication.instance() or QApplication([])
+    yield app

--- a/test/test_smoke.py
+++ b/test/test_smoke.py
@@ -1,0 +1,69 @@
+"""Minimal headless smoke test for OpenHRV (issue #28).
+
+Exercises the most basic construction and logic of the app without opening a
+real window or needing a Bluetooth sensor. Qt runs via the "offscreen"
+platform plugin (see conftest.py), so this is safe in headless CI.
+"""
+
+import math
+
+from openhrv import config
+from openhrv.utils import sign, valid_address, get_sensor_address
+from openhrv.pacer import Pacer
+from openhrv.model import Model
+
+# Reuse the existing mock sensor so we never touch real Bluetooth. Imported as a
+# top-level module (test/ is on sys.path via conftest.py) rather than `test.app`,
+# which would collide with the Python standard library's `test` package.
+from app import MockSensor
+
+
+def test_sign():
+    assert sign(5) == 1
+    assert sign(-5) == -1
+    assert sign(0) == 0
+
+
+def test_breathing_rate_tick_roundtrip():
+    # tick -> rate -> tick must be stable across the supported range.
+    for tick in range(0, 7):
+        rate = config.tick_to_breathing_rate(tick)
+        assert config.MIN_BREATHING_RATE <= rate <= config.MAX_BREATHING_RATE
+        assert config.breathing_rate_to_tick(rate) == tick
+
+
+def test_mock_sensor_address_is_valid():
+    sensor = MockSensor()
+    address = get_sensor_address(sensor)
+    # On Linux/Windows CI runners this resolves to the mock MAC.
+    assert valid_address(address)
+
+
+def test_pacer_radius_within_unit_range(qapp):
+    pacer = Pacer()
+    # breathing_pattern is scaled to [0, 1].
+    for t in (0.0, 1.0, 12.3):
+        radius = pacer.breathing_pattern(config.MAX_BREATHING_RATE, t)
+        assert 0.0 <= radius <= 1.0
+
+    x, y = pacer.update(config.MAX_BREATHING_RATE)
+    assert len(x) == len(y) == len(pacer.cos_theta)
+    # All points lie within the unit disk (radius <= 1).
+    assert all(math.hypot(xi, yi) <= 1.0 + 1e-9 for xi, yi in zip(x, y))
+
+
+def test_model_constructs_with_full_buffers(qapp):
+    model = Model()
+    assert len(model.ibis_buffer) == config.IBI_BUFFER_SIZE
+    assert len(model.hrv_buffer) == config.HRV_BUFFER_SIZE
+    assert config.MIN_HRV_TARGET <= model.hrv_target <= config.MAX_HRV_TARGET
+
+
+def test_model_validates_outlier_ibi(qapp):
+    model = Model()
+    # An absurd IBI (outside [MIN_IBI, MAX_IBI]) is corrected, not stored raw.
+    model.update_ibis_buffer(99_999)
+    assert config.MIN_IBI <= model.ibis_buffer[-1] <= config.MAX_IBI
+    # A physiologically plausible IBI passes through unchanged.
+    model.update_ibis_buffer(900)
+    assert model.ibis_buffer[-1] == 900


### PR DESCRIPTION
Closes #28 — adds a minimal smoke test and runs it in CI.

## What's added

- **`test/test_smoke.py`** — exercises the basic, GUI-free logic without opening a window or needing a Bluetooth sensor: `utils.sign`, the `tick ⇄ breathing_rate` roundtrip and bounds (`config`), `valid_address(get_sensor_address(MockSensor()))`, `Pacer` radius/points within the unit disk, `Model` buffer construction, and `Model.update_ibis_buffer` outlier correction (absurd IBI clamped, plausible IBI passes through).
- **`test/conftest.py`** — sets `QT_QPA_PLATFORM=offscreen` before any `QApplication` is created, plus a session-scoped offscreen `QApplication` fixture (the `Model`/`Pacer` `QObject`s need a running app, but no real window is shown).
- **`.github/workflows/test.yml`** — runs on push/PR (+ manual): installs headless Qt libs, `pip install -e .[test]`, `pytest`. Mirrors the existing `build.yml` style.
- **`pyproject.toml`** — a `test` extra (`pytest`) and pytest config.

## Why it's headless-safe

Qt uses the `offscreen` platform plugin (set in both the workflow env and `conftest.py` before `QApplication`), so no display server is needed. The test reuses the in-repo `MockSensor`, so no Bluetooth. The GUI-launching `test/app.py:main()` is never collected.

## Notes

- The issue referenced `openhrv/test_app.py`, which doesn't exist; the real tests live under `test/`, so the smoke test was added there.
- `MockSensor` is imported as a top-level `app` module (the `test/` dir is on `sys.path` via `conftest.py`) rather than `from test.app import …`, which would collide with the Python standard library's `test` package and fail collection.

Verified locally: `QT_QPA_PLATFORM=offscreen pytest` → **6 passed**.
