### PR TITLE
feat: add "Clear plots" button to reset the data panels (#11)

### DIFF
--- a/openhrv/model.py
+++ b/openhrv/model.py
@@ -28,6 +28,15 @@ class Model(QObject):
 
     def __init__(self):
         super().__init__()
+        self.sensors: list[QBluetoothDeviceInfo] = []
+        self.breathing_rate: float = float(MAX_BREATHING_RATE)
+        self.hrv_target: int = math.ceil((MIN_HRV_TARGET + MAX_HRV_TARGET) / 2)
+        self.reset_buffers()
+
+    def reset_buffers(self):
+        """Reset the IBI/HRV data buffers and derived state to their initial
+        values, e.g. to start a new session (issue #11). Sensor selection and
+        settings (breathing rate, HRV target) are preserved."""
         # Once a bounded length deque is full, when new items are added,
         # a corresponding number of items are discarded from the opposite end.
         self.ibis_buffer: deque[int] = deque([1000] * IBI_BUFFER_SIZE, IBI_BUFFER_SIZE)
@@ -44,9 +53,6 @@ class Model(QObject):
         # - https://en.wikipedia.org/wiki/Exponential_smoothing
         # - http://nestedsoftware.com/2018/04/04/exponential-moving-average-on-streaming-data-4hhl.24876.html
         self.ewma_hrv: float = 1.0
-        self.sensors: list[QBluetoothDeviceInfo] = []
-        self.breathing_rate: float = float(MAX_BREATHING_RATE)
-        self.hrv_target: int = math.ceil((MIN_HRV_TARGET + MAX_HRV_TARGET) / 2)
         self._last_ibi_phase: int = -1
         self._last_ibi_extreme: int = 0
         self._duration_current_phase: int = 0

--- a/openhrv/view.py
+++ b/openhrv/view.py
@@ -276,6 +276,10 @@ class View(QMainWindow):
         self.annotation.setDuplicatesEnabled(False)
         self.annotation_button = QPushButton("Annotate")
         self.annotation_button.clicked.connect(self.emit_annotation)
+
+        self.clear_button = QPushButton("Clear plots")
+        self.clear_button.clicked.connect(self.clear_plots)
+
         self.central_widget = QWidget()
         self.setCentralWidget(self.central_widget)
 
@@ -325,6 +329,7 @@ class View(QMainWindow):
         # row, column, rowspan, columnspan
         self.recording_config.addWidget(self.annotation, 1, 0, 1, 2)
         self.recording_config.addWidget(self.annotation_button, 1, 2)
+        self.recording_config.addWidget(self.clear_button, 2, 0, 1, 3)
         self.recording_panel = QGroupBox("Recording")
         self.recording_panel.setLayout(self.recording_config)
         self.hlayout1.addWidget(self.recording_panel, stretch=25)
@@ -381,6 +386,17 @@ class View(QMainWindow):
 
     def plot_hrv(self, hrv: NamedSignal):
         self.hrv_widget.update_series(*hrv.value)
+
+    def clear_plots(self):
+        """Reset the IBI and HRV plots for a new session (issue #11).
+
+        Redraws the series directly instead of routing through the model's
+        update signals, so clearing the live view never writes baseline samples
+        to an ongoing recording.
+        """
+        self.model.reset_buffers()
+        self.ibis_widget.update_series(self.model.ibis_seconds, self.model.ibis_buffer)
+        self.hrv_widget.update_series(self.model.hrv_seconds, self.model.hrv_buffer)
 
     def list_addresses(self, addresses: NamedSignal):
         self.address_menu.clear()

--- a/test/test_smoke.py
+++ b/test/test_smoke.py
@@ -67,3 +67,21 @@ def test_model_validates_outlier_ibi(qapp):
     # A physiologically plausible IBI passes through unchanged.
     model.update_ibis_buffer(900)
     assert model.ibis_buffer[-1] == 900
+
+
+def test_model_reset_buffers_restores_baseline(qapp):
+    baseline = Model()
+    model = Model()
+    # Push real data so the buffers and derived state diverge from baseline.
+    for ibi in (850, 950, 1050, 900, 1000):
+        model.update_ibis_buffer(ibi)
+    assert list(model.ibis_buffer) != list(baseline.ibis_buffer)
+
+    model.reset_buffers()
+
+    assert list(model.ibis_buffer) == list(baseline.ibis_buffer)
+    assert list(model.hrv_buffer) == list(baseline.hrv_buffer)
+    assert list(model.ibis_seconds) == list(baseline.ibis_seconds)
+    assert list(model.hrv_seconds) == list(baseline.hrv_seconds)
+    assert model.ewma_hrv == baseline.ewma_hrv
+    assert model._duration_current_phase == 0


### PR DESCRIPTION
Closes #11.

Adds a **Clear plots** button to the Recording panel that resets the IBI and HRV plots, so a recording session can be restarted without relaunching the app (as requested in #11).

### Changes
- `Model.reset_buffers()` — factors buffer/state init out of `__init__` and returns the IBI/HRV deques, EWMA, and phase-tracking state to baseline. Sensor selection and settings (breathing rate, HRV target) are preserved.
- `View.clear_plots()` — calls `reset_buffers()` then redraws the two series directly. It intentionally does **not** route through the model's `*_update` signals (those are also wired to `Logger.write_to_file`), so clearing the live view never injects baseline samples into an ongoing recording.
- Button placed in the Recording panel and labelled "Clear plots" to make clear it resets the on-screen panels, not the recording file.
- Added a headless unit test (`test_model_reset_buffers_restores_baseline`) alongside the existing smoke tests.

### Verification
- `pytest` green (7 passed) headless via the offscreen platform plugin.
- Manually exercised `View.clear_plots()` headless: after pushing IBIs, both series redraw to baseline.

Happy to add a `changelog.md` line under whichever version you cut next.