### PR TITLE
docs: document the session recording feature (#10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,31 @@ an HRV of 500 msec". Try to increase HRV relative to what you have achieved befo
 and be aware that it can take a fair bit of practice to improve.
 
 ![biofeedback_demo](https://github.com/JanCBrammer/OpenHRV/raw/main/docs/biofeedback_demo.gif)
+
+### Record a session
+You can record a session to a `.csv` file using the controls in the `Recording`
+panel. Click `Start` and choose where to save the file. The dialog suggests a
+name based on the current date and time (e.g. `OpenHRV_2025-12-19-14-30.csv`);
+recording only begins if the file doesn't exist yet, so each session is written
+to its own file. Click `Save` to stop recording and close the file. The session
+is also saved automatically when you close **OpenHRV** while a recording is running.
+
+While recording, **OpenHRV** appends one row per data point. Each row has three
+columns, `event,value,timestamp`, where `timestamp` is in ISO 8601 format. The
+following events are logged:
+
+| event | value |
+| --- | --- |
+| `InterBeatInterval` | latest inter-beat interval (msec) |
+| `HeartRateVariability` | latest (smoothed) HRV (msec) |
+| `HrvTarget` | HRV target whenever you move the `Target` slider |
+| `PacerRate` | breathing rate whenever you move the `Rate` slider |
+| `Sensors` | sensor that became available or connected |
+| `Annotation` | a note you added (see below) |
+
+#### Annotate a recording
+Use the annotation field next to the `Annotate` button to mark moments of
+interest in a recording, for example the start of an exercise or a change in how
+you feel. Type a label (or pick a previously used one from the drop-down) and
+click `Annotate` to write an `Annotation` row with your label and the current
+timestamp. Annotations are only recorded while a recording is running.


### PR DESCRIPTION
Closes #10.

Adds a **Record a session** section to the README user guide. It documents the `Recording` panel, which previously had no end-user docs:

- How to **Start** / **Save** a recording (and that it auto-saves on app close), and that each session writes to its own new `.csv` file.
- The CSV schema (`event,value,timestamp`, ISO 8601 timestamp) and a table of the logged events: `InterBeatInterval`, `HeartRateVariability`, `HrvTarget`, `PacerRate`, `Sensors`, `Annotation`.
- A short **Annotate a recording** subsection on using the annotation field to mark moments of interest.

Documentation only — no code changes. Content was derived from `logger.py` / `view.py`; happy to adjust wording or add a screenshot/GIF if you'd like one to match the other guide sections.